### PR TITLE
feat: add setDevice for self

### DIFF
--- a/demo/video/src/Video/DemoHooks/DeviceChangeButton.tsx
+++ b/demo/video/src/Video/DemoHooks/DeviceChangeButton.tsx
@@ -1,11 +1,9 @@
-import { Video } from "@signalwire/js";
-
 export function DeviceChangeButton({
-  roomSession,
+  self,
   kind,
   device,
 }: {
-  roomSession: Video.RoomSession;
+  self: any;
   kind: "camera" | "speaker" | "microphone";
   device: MediaDeviceInfo;
 }) {
@@ -15,12 +13,9 @@ export function DeviceChangeButton({
       href="#"
       onClick={(x) => {
         x.preventDefault();
-        if (kind === "camera")
-          roomSession.updateCamera({ deviceId: device.deviceId });
-        if (kind === "microphone")
-          roomSession.updateMicrophone({ deviceId: device.deviceId });
-        if (kind === "speaker")
-          roomSession.updateSpeaker({ deviceId: device.deviceId });
+        if (kind === "camera") self.video.setDevice(device);
+        if (kind === "microphone") self.audio.setDevice(device);
+        if (kind === "speaker") self.speaker.setDevice(device);
       }}
     >
       {device.label}

--- a/demo/video/src/Video/DemoHooks/index.tsx
+++ b/demo/video/src/Video/DemoHooks/index.tsx
@@ -88,7 +88,7 @@ function DemoHooks() {
             <DeviceChangeButton
               key={x.deviceId}
               kind="camera"
-              roomSession={roomSession}
+              self={members.self}
               device={x}
             />
           ))}
@@ -97,7 +97,7 @@ function DemoHooks() {
             <DeviceChangeButton
               key={x.deviceId}
               kind="microphone"
-              roomSession={roomSession}
+              self={members.self}
               device={x}
             />
           ))}
@@ -106,7 +106,7 @@ function DemoHooks() {
             <DeviceChangeButton
               key={x.deviceId}
               kind="speaker"
-              roomSession={roomSession}
+              self={members.self}
               device={x}
             />
           ))}

--- a/packages/react/src/hooks/useMembers.ts
+++ b/packages/react/src/hooks/useMembers.ts
@@ -7,7 +7,7 @@ import type {
 import type { SetMemberPositionParams } from "@signalwire/core/dist/core/src/rooms";
 import type { VideoMemberListUpdatedParams } from "@signalwire/js/dist/js/src/video";
 
-type DeviceId = {
+type DeviceIdHolder = {
   deviceId: string;
   [x: string | number | symbol]: unknown;
 };
@@ -19,7 +19,7 @@ interface IOAttributes {
   toggle: () => void;
 }
 interface SelfIOAttributes extends IOAttributes {
-  setDevice: (device: DeviceId) => void;
+  setDevice: (device: DeviceIdHolder) => void;
 }
 interface Member extends VideoMemberEntity {
   audio: IOAttributes;
@@ -147,13 +147,13 @@ export default function useMembers(roomSession: Video.RoomSession | null): {
     const self: Self | null =
       (members.find((m: any) => m.id === selfId.current) as Self) ?? null;
     if (self != null) {
-      self.audio.setDevice = (device: DeviceId) => {
+      self.audio.setDevice = (device: DeviceIdHolder) => {
         roomSession?.updateMicrophone(device);
       };
-      self.video.setDevice = (device: DeviceId) => {
+      self.video.setDevice = (device: DeviceIdHolder) => {
         roomSession?.updateCamera(device);
       };
-      self.speaker.setDevice = (device: DeviceId) => {
+      self.speaker.setDevice = (device: DeviceIdHolder) => {
         roomSession?.updateSpeaker(device);
       };
     }

--- a/packages/react/src/hooks/useMembers.ts
+++ b/packages/react/src/hooks/useMembers.ts
@@ -7,6 +7,11 @@ import type {
 import type { SetMemberPositionParams } from "@signalwire/core/dist/core/src/rooms";
 import type { VideoMemberListUpdatedParams } from "@signalwire/js/dist/js/src/video";
 
+type DeviceId = {
+  deviceId: string;
+  [x: string | number | symbol]: unknown;
+};
+
 interface Member extends VideoMemberEntity {
   audio: {
     muted: boolean;
@@ -135,8 +140,24 @@ export default function useMembers(roomSession: Video.RoomSession | null) {
     };
   }, [roomSession]);
 
+  function getSelfMember() {
+    const self: any = members.find((m: any) => m.id === selfId.current) ?? null;
+    if (self != null) {
+      self.audio.setDevice = (device: DeviceId) => {
+        roomSession?.updateMicrophone(device);
+      };
+      self.video.setDevice = (device: DeviceId) => {
+        roomSession?.updateCamera(device);
+      };
+      self.speaker.setDevice = (device: DeviceId) => {
+        roomSession?.updateSpeaker(device);
+      };
+    }
+    return self;
+  }
+
   return {
-    self: members.find((m: any) => m.id === selfId.current) ?? null,
+    self: getSelfMember(),
     members,
     removeAll: () => {
       roomSession?.removeAllMembers();

--- a/packages/react/src/hooks/useMembers.ts
+++ b/packages/react/src/hooks/useMembers.ts
@@ -12,27 +12,26 @@ type DeviceId = {
   [x: string | number | symbol]: unknown;
 };
 
+interface IOAttributes {
+  muted: boolean;
+  mute: () => void;
+  unmute: () => void;
+  toggle: () => void;
+}
+interface SelfIOAttributes extends IOAttributes {
+  setDevice: (device: DeviceId) => void;
+}
 interface Member extends VideoMemberEntity {
-  audio: {
-    muted: boolean;
-    mute: () => void;
-    unmute: () => void;
-    toggle: () => void;
-  };
-  video: {
-    muted: boolean;
-    mute: () => void;
-    unmute: () => void;
-    toggle: () => void;
-  };
-  speaker: {
-    muted: boolean;
-    mute: () => void;
-    unmute: () => void;
-    toggle: () => void;
-  };
+  audio: IOAttributes;
+  video: IOAttributes;
+  speaker: IOAttributes;
   remove: () => void;
   setPosition: (position: string) => void;
+}
+interface Self extends Member {
+  audio: SelfIOAttributes;
+  video: SelfIOAttributes;
+  speaker: SelfIOAttributes;
 }
 
 /**
@@ -42,9 +41,13 @@ interface Member extends VideoMemberEntity {
  * `members` as an array with the list of all members, and `removeAll()`
  * which removes everyone
  */
-export default function useMembers(roomSession: Video.RoomSession | null) {
+export default function useMembers(roomSession: Video.RoomSession | null): {
+  self: Self | null;
+  members: Member[];
+  removeAll: () => void;
+} {
   const selfId = useRef<string | null>(null);
-  const [members, setMembers] = useState<VideoMemberEntity[]>([]);
+  const [members, setMembers] = useState<Member[]>([]);
 
   useEffect(() => {
     if (roomSession === null || roomSession === undefined) return;
@@ -140,8 +143,9 @@ export default function useMembers(roomSession: Video.RoomSession | null) {
     };
   }, [roomSession]);
 
-  function getSelfMember() {
-    const self: any = members.find((m: any) => m.id === selfId.current) ?? null;
+  function getSelfMember(): null | Self {
+    const self: Self | null =
+      (members.find((m: any) => m.id === selfId.current) as Self) ?? null;
     if (self != null) {
       self.audio.setDevice = (device: DeviceId) => {
         roomSession?.updateMicrophone(device);


### PR DESCRIPTION
Added temporary convenience functions to set device till the time when we can create a proper `useDevices` hook (https://github.com/signalwire/cloud-product/issues/4714).